### PR TITLE
Fix an error at TaskAbstract.php line 174

### DIFF
--- a/src/Abstracts/TaskAbstract.php
+++ b/src/Abstracts/TaskAbstract.php
@@ -171,7 +171,7 @@ abstract class TaskAbstract
      */
     private function validate(
         $curl,
-        string $response,
+        ?string $response,
         string $error
     ): void {
         if ($error) {


### PR DESCRIPTION
In some rare cases, the connection may fail and exec_curl may return a boolean instead of a string. Because the response is declared as a string at validation method, this results in an error and the script fails before reaching the function. A simple solution is to add a question mark before the response type declaration to convert the boolean to null. I avoided string|false to keep supporting >=7.4 PHP.